### PR TITLE
Feat/add json neurips 2022

### DIFF
--- a/data/json/papers.md
+++ b/data/json/papers.md
@@ -37,7 +37,7 @@
 |  年  | ソース | 論文数（スクレイプ結果）| メモ |
 | ---- | ---- | ---- | ---- |
 | 2023 | https://papers.nips.cc/paper_files/paper/2023 | 3218 |
-| 2022 | https://papers.nips.cc/paper_files/paper/2022 | <ここ埋める> | - アイテム1<br>- アイテム2<br>- アイテム3
+| 2022 | https://papers.nips.cc/paper_files/paper/2022 | 2671 | - アイテム1<br>- アイテム2<br>- アイテム3
 | 2021 | https://papers.nips.cc/paper_files/paper/2021 | <ここ埋める> |
 | 2020 | https://papers.nips.cc/paper_files/paper/2020 | <ここ埋める> |
 | 2019 | https://papers.nips.cc/paper_files/paper/2019 | <ここ埋める> |


### PR DESCRIPTION
## Issue URL

NeurIPS 2022の論文情報の一覧を取得する
close: #10 

## Change overview

`data/json`下に`neurips2022_papers.json`を追加する
papers.mdを更新

## How to test

NA

## Note for reviewers

2671 　https://papercopilot.com/statistics/neurips-statistics/neurips-2022-statistics/

INFO:main:Successfully parsed 2671 papers.

NeurIPS 2022の論文採択数とJSONファイル内の数が一致している

