### PR TITLE
:kaaba: extend scraper of CVF for cvpr2020, iccv2019

### DIFF
--- a/src/cvf.py
+++ b/src/cvf.py
@@ -55,9 +55,7 @@ def get_paper_page_urls(conference: str, year: int) -> list[str]:
     conference_name: Final[str] = validate_conference(conference, year)
 
     # 発表日ごとの表示しか出来ない場合
-    if (conference == "cvpr" and year == 2020) or (
-        conference == "iccv" and year == 2019
-    ):
+    if int(year) <= 2000:
         cvf_all_paper_url = cvf_root_url + f"/{conference_name}"
 
         html = requests.get(cvf_all_paper_url).text

--- a/src/cvf.py
+++ b/src/cvf.py
@@ -55,7 +55,7 @@ def get_paper_page_urls(conference: str, year: int) -> list[str]:
     conference_name: Final[str] = validate_conference(conference, year)
 
     # 発表日ごとの表示しか出来ない場合
-    if int(year) <= 2000:
+    if int(year) <= 2020:
         cvf_all_paper_url = cvf_root_url + f"/{conference_name}"
 
         html = requests.get(cvf_all_paper_url).text


### PR DESCRIPTION
## Issue URL

CVPR 2020のページやICCV 2019のページもスクレイプする必要があるが、2020以前のページは論文の一覧表示は出来ず、発表日ごとの表示しか出来ないので工夫する

close: #5 

## Change overview

既存のcvf.pyを拡張する形で実装を行った

```python
    if (conference == "cvpr" and year == 2020) or (conference == "iccv" and year == 2019):
```
で分岐を行っています
今回はCVPR2020とICCV2019に特化した条件分岐です

保存されるJSONの形式は`data/json/cvpr2023_papers.json`と同じです

## How to test

```
poetry run python src/scripts/scrape_conference_page.py -c cvpr -y 2020
```

## Note for reviewers

NA
