### PR TITLE
chore: update Python version in CI workflows to 3.12

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.12"]
         include:
           - os: ubuntu
             image: ubuntu-latest

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.12"]
         include:
           - os: ubuntu
             image: ubuntu-latest


### PR DESCRIPTION
## Issue URL

NA

## Change overview

This pull request updates the GitHub Actions workflows to use Python 3.12 instead of Python 3.8 and 3.9. The changes ensure that the workflows are aligned with the latest supported Python version.

Workflow updates:

* [`.github/workflows/cache.yaml`](diffhunk://#diff-04c44f0ccda191588a97300b66a9205fe6e56726568a767c546e20d644d24a0fL24-R24): Updated the `python-version` matrix to use only Python 3.12.
* [`.github/workflows/lint-and-test.yaml`](diffhunk://#diff-733fa1a1798b2a08a08b8c4f2ae7c7a0d7bfd9e0eb6e8796f60ef5428ba3a335L20-R20): Updated the `python-version` matrix to use only Python 3.12.

## How to test

NA

## Note for reviewers

NA
