### PR TITLE
feat: add cvpr 2025

### DIFF
--- a/src/cvf.py
+++ b/src/cvf.py
@@ -99,9 +99,9 @@ def validate_conference(conference: str, year: int) -> str:
         str: The unique conference name with year.
     """
     if conference == "cvpr":
-        if year not in range(2013, 2025):
+        if year not in range(2013, 2026):
             raise ValueError(
-                "CVPR conference is held from 2013 to 2024. \
+                "CVPR conference is held from 2013 to 2025. \
                 Please specify the year in the range."
             )
         return f"CVPR{year}"


### PR DESCRIPTION
This pull request updates the validation logic for conference years in the `validate_conference` function within `src/cvf.py`. The change extends the acceptable year range for the CVPR conference by one year.

* [`src/cvf.py`](diffhunk://#diff-910e80ac1e50af57cd1f8568d0d04e102f757fcfad2edcaf4b6509cd954462fbL102-R104): Updated the year range for CVPR conferences to include 2025 and adjusted the error message accordingly.
